### PR TITLE
fixes #3

### DIFF
--- a/lib/visual-bell.coffee
+++ b/lib/visual-bell.coffee
@@ -5,7 +5,7 @@ module.exports =
     enabled: true
 
   activate: ->
-    atom.workspaceView.on 'beep', =>
+    atom.views.getView(atom.workspace).on 'beep', =>
       return unless atom.config.get('visual-bell.enabled')
       @addOverlay()
       setTimeout((=> @removeOverlay()), 300)


### PR DESCRIPTION
atom.workspaceView is no longer available.
In most cases you will not need the view. See the Workspace docs for
alternatives: https://atom.io/docs/api/latest/Workspace.
If you do need the view, please use `atom.views.getView(atom.workspace)`,
which returns an HTMLElement.
```
Atom.Object.defineProperty.get (/opt/homebrew-cask/Caskroom/atom/latest/Atom.app/Contents/Resources/app/src/atom.js:55:11)
Object.activate (/Users/tcarlsen/.dotfiles/atom.symlink/packages/visual-bell/lib/visual-bell.coffee:8:9)
```